### PR TITLE
Remove Fall Die Reason and Accept Any

### DIFF
--- a/pvp_club/init.lua
+++ b/pvp_club/init.lua
@@ -193,7 +193,7 @@ mt.register_on_dieplayer(function (player, reason)
         ms:set_string(player:get_player_name().."deaths", tostring(deaths + 1))
 	ms:set_string(reason.object:get_player_name().."score", tostring(score + 10))
 	mt.chat_send_all(mt.colorize(PVP.team_color(reason.object:get_player_name()), reason.object:get_player_name())..mt.colorize("#FF0000", " has killed ")..mt.colorize(PVP.team_color(player:get_player_name()), player:get_player_name()))
-    elseif reason.type == "fall" then
+    else
         local deaths = tonumber(ms:get_string(player:get_player_name().."deaths")) or 0
         ms:set_string(player:get_player_name().."deaths", tostring(deaths + 1))
     end


### PR DESCRIPTION
Player may also die by `node_damage` like fire or lava. Deaths should be considered even there. 